### PR TITLE
Use nodejs 6.10 for lambda runtime

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: hammertime
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   memorySize: 128
   stage: ${env:SLICE}
   region: ap-southeast-2


### PR DESCRIPTION
Fixes #12 