### PR TITLE
dont hammertime aurora instances

### DIFF
--- a/src/rds/allValidDBInstances.js
+++ b/src/rds/allValidDBInstances.js
@@ -1,5 +1,6 @@
 module.exports = function allValidDBInstances(instance) {
   return (
+    instance.StorageType != 'aurora' &&
     instance.DBInstanceStatus == this &&
     instance.MultiAZ == false &&
     instance.ReadReplicaDBInstanceIdentifiers.length == 0 &&


### PR DESCRIPTION
The lambda currently throws an error (below) and terminates when it attempts to hammertime RDS aurora instances. This error prevents the remainder of the lambda from finishing its execution, resulting in potentially viable targets being ignored.

`InvalidParameterCombination: aurora-postgresql DB instances are not eligible for stopping and starting.`