### PR TITLE
Hammertime Fargate ECS Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Build Status](https://travis-ci.org/nib-health-funds/hammertime.svg?branch=master)](https://travis-ci.org/nib-health-funds/hammertime)
 
-Serverless power cycling for AWS EC2, RDS instances and Auto Scaling Groups based on a schedule.
+Serverless power cycling for AWS EC2, RDS instances, Auto Scaling Groups, and Fargate based on a schedule.
 
 ![Stop! Hammer Time!](hammertime.gif)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,20 +1600,26 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "aws-sdk": {
-      "version": "2.167.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.167.0.tgz",
-      "integrity": "sha1-8gff9/fpp4g9O2m9IlE0RJaKNr0=",
+      "version": "2.610.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.610.0.tgz",
+      "integrity": "sha512-kqcoCTKjbxrUo2KeLQR2Jw6l4PvkbHXSDk8KqF2hXcpHibiOcMXZZPVe9X+s90RC/B2+qU95M7FImp9ByMcw7A==",
       "requires": {
         "buffer": "4.9.1",
-        "crypto-browserify": "1.0.9",
-        "events": "^1.1.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.1.0",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        }
       }
     },
     "aws-sdk-mock": {
@@ -3322,11 +3328,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "crypto-browserify": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
-      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -5391,6 +5392,12 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5495,6 +5502,12 @@
       "requires": {
         "number-is-nan": "^1.0.0"
       }
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
@@ -7121,6 +7134,12 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
       "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
@@ -7144,6 +7163,116 @@
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.0",
         "object-keys": "^1.0.10"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-abstract": {
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -8681,6 +8810,60 @@
         "strip-ansi": "^3.0.0"
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -9490,18 +9673,22 @@
       }
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
+      "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "dev": true
         }
       }
@@ -9517,9 +9704,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -9680,21 +9867,18 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "^4.0.0"
-      }
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/register": "^7.6.2",
-    "aws-sdk": "^2.7.19",
+    "aws-sdk": "^2.610.0",
     "luxon": "^1.11.4",
     "moment": "^2.22.1",
     "nyc": "^14.1.1",
@@ -34,7 +34,7 @@
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.3",
     "@istanbuljs/nyc-config-babel": "^2.1.1",
-    "aws-sdk-mock": "^1.6.1",
+    "aws-sdk-mock": "^1.7.0",
     "babel-plugin-istanbul": "^5.2.0",
     "babel-register": "^6.26.0",
     "chai": "^3.5.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,6 +29,7 @@ provider:
         - 'ecs:DescribeServices'
         - 'ecs:DescribeClusters'
         - 'ecs:ListTagsForResource'
+        - 'ecs:TagResource'
         - 'ecs:UntagResource'
         - 'ecs:UpdateService'
       Resource: '*'

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,6 +24,12 @@ provider:
         - 'autoscaling:DeleteTags'
         - 'autoscaling:DescribeAutoScalingGroups'
         - 'autoscaling:UpdateAutoScalingGroup'
+        - 'ecs:ListClusters'
+        - 'ecs:ListServices'
+        - 'ecs:DescribeServices'
+        - 'ecs:ListTagsForResource'
+        - 'ecs:UntagResource'
+        - 'ecs:UpdateService'
       Resource: '*'
     - Effect: Allow
       Action:

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,6 +27,7 @@ provider:
         - 'ecs:ListClusters'
         - 'ecs:ListServices'
         - 'ecs:DescribeServices'
+        - 'ecs:DescribeClusters'
         - 'ecs:ListTagsForResource'
         - 'ecs:UntagResource'
         - 'ecs:UpdateService'

--- a/src/ecs/listServicesToStart.js
+++ b/src/ecs/listServicesToStart.js
@@ -6,6 +6,7 @@ function startableService(service) {
   if (!service.tags) { return false; }
 
   service.tags.map(tag => tag.Key = tag.key);
+  service.tags.map(tag => tag.Value = tag.value);
   return hasTag(service.tags, 'stop:hammertime') && canITouchThis(service.tags);
 }
 

--- a/src/ecs/listServicesToStart.js
+++ b/src/ecs/listServicesToStart.js
@@ -1,0 +1,16 @@
+const hasTag = require('../tags/hasTag');
+const listTargetServices = require('./listTargetServices');
+const canITouchThis = require('../tags/canITouchThis');
+
+function startableService(service) {
+  if (!service.tags) { return false; }
+
+  service.tags.map(tag => tag.Key = tag.key);
+  return hasTag(service.tags, 'stop:hammertime') && canITouchThis(service.tags);
+}
+
+function listServicesToStart(currentOperatingTimezone) {
+  return listTargetServices(startableService, currentOperatingTimezone);
+}
+
+module.exports = listServicesToStart;

--- a/src/ecs/listServicesToStop.js
+++ b/src/ecs/listServicesToStop.js
@@ -6,6 +6,7 @@ function stoppableService(service) {
   if (!service.tags) { return false; }
 
   service.tags.map(tag => tag.Key = tag.key);
+  service.tags.map(tag => tag.Value = tag.value);
   return !hasTag(service.tags, 'stop:hammertime') && canITouchThis(service.tags);
 }
 

--- a/src/ecs/listServicesToStop.js
+++ b/src/ecs/listServicesToStop.js
@@ -1,0 +1,16 @@
+const hasTag = require('../tags/hasTag');
+const listTargetServices = require('./listTargetServices');
+const canITouchThis = require('../tags/canITouchThis');
+
+function stoppableService(service) {
+  if (!service.tags) { return false; }
+
+  service.tags.map(tag => tag.Key = tag.key);
+  return !hasTag(service.tags, 'stop:hammertime') && canITouchThis(service.tags);
+}
+
+function listServicesToStop(currentOperatingTimezone) {
+  return listTargetServices(stoppableService, currentOperatingTimezone);
+}
+
+module.exports = listServicesToStop;

--- a/src/ecs/listTargetServices.js
+++ b/src/ecs/listTargetServices.js
@@ -1,0 +1,79 @@
+const AWS = require('aws-sdk');
+const isInOperatingTimezone = require('../operatingTimezone/isInOperatingTimezone');
+const retryWhenThrottled = require('../utils/retryWhenThrottled');
+
+async function getAllClusters(clusters, token) {
+  const ECS = new AWS.ECS();
+  const params = { nextToken: token };
+  const response = await retryWhenThrottled(() => ECS.listClusters(params));
+  let clusterArray = [];
+  if (clusters) clusterArray = [...clusterArray, ...clusters];
+  if (response.clusterArns) clusterArray = [...clusterArray, ...response.clusterArns];
+  if (response.nextToken) return getAllClusters(clusterArray, response.nextToken);
+  return clusterArray;
+}
+
+async function describeAllClusters(clusters) {
+  const chunks = chunkArray(clusters, 100);
+  const data = await Promise.all(chunks.map(chunk => describeChunkOfClusters(chunk)));
+  const clusterArns = [].concat(...data).map(cluster => cluster.clusterArn);
+  return clusterArns;
+}
+
+async function describeChunkOfClusters(clusters) {
+  // Expects no more than 100 clusters.
+  const ECS = new AWS.ECS();
+  const params = { clusters };
+  const response = await retryWhenThrottled(() => ECS.describeClusters(params));
+  return response.clusters;
+}
+
+async function getAllServices(clusterArnList) {
+  const data = await Promise.all(clusterArnList.map(clusterArn => getService(clusterArn)));
+  return data.filter(cluster => cluster.services.length > 0);
+}
+
+async function getService(clusterArn) {
+  const ECS = new AWS.ECS();
+  const params = { cluster: clusterArn, launchType: 'FARGATE' };
+  const response = await retryWhenThrottled(() => ECS.listServices(params));
+  return { cluster: clusterArn, services: response.serviceArns };
+}
+
+async function describeServices(clusterList) {
+  const services = await Promise.all(clusterList.map(cluster => describeService(cluster)));
+  return [].concat(...services);
+}
+
+async function describeService(service) {
+  const ECS = new AWS.ECS();
+  const params = {
+    services: service.services,
+    cluster: service.cluster,
+    include: ['TAGS'],
+  };
+  const response = await retryWhenThrottled(() => ECS.describeServices(params));
+  return response.services;
+}
+
+function isServiceInCurrentOperatingTimezone(currentOperatingTimezone) {
+  const isInCurrentOperatingTimezone = isInOperatingTimezone(currentOperatingTimezone);
+  return service => isInCurrentOperatingTimezone(service.tags);
+}
+
+function chunkArray(array, size) {
+  if (array.length <= size) return [array];
+  return [array.slice(0, size), ...chunkArray(array.slice(size), size)];
+}
+
+function filterClusters(filter, currentOperatingTimezone) {
+  return getAllClusters([], null)
+    .then(data => describeAllClusters(data))
+    .then(data => getAllServices(data))
+    .then(data => describeServices(data))
+    .then(data => data
+      .filter(filter)
+      .filter(isServiceInCurrentOperatingTimezone(currentOperatingTimezone)));
+}
+
+module.exports = filterClusters;

--- a/src/ecs/startServices.js
+++ b/src/ecs/startServices.js
@@ -1,0 +1,19 @@
+const AWS = require('aws-sdk');
+const retryWhenThrottled = require('../utils/retryWhenThrottled');
+
+function startService(service) {
+  const ECS = new AWS.ECS();
+  const originalServiceSize = service.tags.find(tag => tag.key === 'hammertime:originalServiceSize').value;
+  const params = {
+    cluster: service.clusterArn,
+    service: service.serviceArn,
+    desiredCount: originalServiceSize,
+  };
+  return retryWhenThrottled(() => ECS.updateService(params)).then(() => service);
+}
+
+function startServices(services) {
+  return Promise.all(services.map(service => startService(service)));
+}
+
+module.exports = startServices;

--- a/src/ecs/stopServices.js
+++ b/src/ecs/stopServices.js
@@ -1,0 +1,18 @@
+const AWS = require('aws-sdk');
+const retryWhenThrottled = require('../utils/retryWhenThrottled');
+
+function spinDownService(service) {
+  const ECS = new AWS.ECS();
+  const params = {
+    cluster: service.clusterArn,
+    service: service.serviceArn,
+    desiredCount: 0,
+  };
+  return retryWhenThrottled(() => ECS.updateService(params)).then(() => service);
+}
+
+function stopServices(services) {
+  return Promise.all(services.map(service => spinDownService(service)));
+}
+
+module.exports = stopServices;

--- a/src/ecs/tagServices.js
+++ b/src/ecs/tagServices.js
@@ -1,0 +1,20 @@
+const AWS = require('aws-sdk');
+const retryWhenThrottled = require('../utils/retryWhenThrottled');
+
+function tagService(service) {
+  const ECS = new AWS.ECS();
+  const params = {
+    resourceArn: service.serviceArn,
+    tags: [
+      { key: 'hammertime:originalServiceSize', value: service.desiredCount.toString() },
+      { key: 'stop:hammertime', value: new Date().toISOString() },
+    ],
+  };
+  return retryWhenThrottled(() => ECS.tagResource(params)).then(() => service);
+}
+
+function tagServices(services) {
+  return Promise.all(services.map(service => tagService(service)));
+}
+
+module.exports = tagServices;

--- a/src/ecs/untagServices.js
+++ b/src/ecs/untagServices.js
@@ -1,0 +1,18 @@
+const AWS = require('aws-sdk');
+const retryWhenThrottled = require('../utils/retryWhenThrottled.js');
+
+const untagService = (service) => {
+  const ECS = new AWS.ECS();
+  const params = {
+    tagKeys: [
+      'hammertime:originalServiceSize',
+      'stop:hammertime',
+    ],
+    resourceArn: service.serviceArn,
+  };
+  return retryWhenThrottled(() => ECS.untagResource(params)).then(() => service);
+};
+
+const untagServices = services => Promise.all(services.map(service => untagService(service)));
+
+module.exports = untagServices;

--- a/src/start.js
+++ b/src/start.js
@@ -104,9 +104,7 @@ function spinUpServices(dryRun, currentOperatingTimezone){
     if (dryRun) {
       console.log('Dry run is enabled, will not start or untag any services.');
       console.log(`Found the following ${startableServices.length} service[s] that would have been spun up`);
-      startableServices.forEach((service) => {
-          console.log(service.serviceName);
-      })
+      startableServices.map((service) => console.log(service.serviceName));
       return [];
     }
 
@@ -116,9 +114,7 @@ function spinUpServices(dryRun, currentOperatingTimezone){
     }
 
     console.log(`Found the following ${startableServices.length} services[s] to start...`);
-    startableServices.forEach((service) => {
-      console.log(service.serviceName);
-    })
+    startableServices.map((service) => console.log(service.serviceName));
 
     return startServices(startableServices).then((startedServiceIds) => {
       console.log('Finished starting service[s]. Moving on to untag them.');

--- a/src/start.js
+++ b/src/start.js
@@ -131,7 +131,7 @@ module.exports = function start(options) {
     startAllDBInstances(dryRun),
     startAllInstances({ dryRun, currentOperatingTimezone }),
     spinUpASGs({ dryRun, currentOperatingTimezone }),
-    spinUpServices({ dryRun, currentOperatingTimezone })
+    spinUpServices(dryRun, currentOperatingTimezone)
   ]).then(() => {
     if (!dryRun) {
       console.log('All EC2, RDS instances, ASGs, and ECS services started successfully. Good morning!');

--- a/src/start.js
+++ b/src/start.js
@@ -98,7 +98,7 @@ function startAllDBInstances(dryRun) {
     });
 }
 
-function spinUpServices(dryRun, currentOperatingTimezone){
+function spinUpServices({ dryRun, currentOperatingTimezone }){
   return listServicesToStart(currentOperatingTimezone)
   .then((startableServices) => {
     if (dryRun) {
@@ -131,7 +131,7 @@ module.exports = function start(options) {
     startAllDBInstances(dryRun),
     startAllInstances({ dryRun, currentOperatingTimezone }),
     spinUpASGs({ dryRun, currentOperatingTimezone }),
-    spinUpServices(dryRun, currentOperatingTimezone)
+    spinUpServices({ dryRun, currentOperatingTimezone })
   ]).then(() => {
     if (!dryRun) {
       console.log('All EC2, RDS instances, ASGs, and ECS services started successfully. Good morning!');

--- a/src/stop.js
+++ b/src/stop.js
@@ -104,7 +104,7 @@ function stopAllDBInstances(dryRun) {
     });
 }
 
-function spinDownServices(dryRun, currentOperatingTimezone){
+function spinDownServices({ dryRun, currentOperatingTimezone }){
   return listServicesToStop(currentOperatingTimezone)
     .then((stoppableServices) => {
       if (dryRun) {
@@ -145,7 +145,7 @@ module.exports = function stop(options) {
     stopAllDBInstances(dryRun),
     stopAllInstances({ dryRun, currentOperatingTimezone }),
     spinDownASGs({ dryRun, currentOperatingTimezone }),
-    spinDownServices(dryRun, currentOperatingTimezone)
+    spinDownServices({ dryRun, currentOperatingTimezone })
   ]).then(() => {
     if (!dryRun) {
       console.log('All EC2, RDS instances, ASGs, and ECS services stopped successfully. Good night!');

--- a/src/utils/retryWhenThrottled.js
+++ b/src/utils/retryWhenThrottled.js
@@ -4,7 +4,7 @@ module.exports = function retryWhenThrottled(func) {
   return promiseRetry((retry, number) => func()
     .promise()
     .catch((err) => {
-      if (err.code === 'Throttling') {
+      if (err.code === 'Throttling' || err.code === 'ThrottlingException') {
         console.warn(`Throttled by the AWS API. Backing off... (${number}/10)`);
         retry(err);
       }

--- a/test/ecs/listServicesToStart.test.js
+++ b/test/ecs/listServicesToStart.test.js
@@ -1,0 +1,41 @@
+const assert = require("assert");
+const AWS = require("aws-sdk-mock");
+const listServicesToStart = require("../../src/ecs/listServicesToStart");
+const defaultOperatingTimezone = require("../../src/config").defaultOperatingTimezone;
+const data = require("./mockData");
+
+describe("listServicesToStart()", () => {
+  beforeEach(() => {
+    AWS.mock("ECS", "describeServices", (params, callback) =>
+      callback(null, data.describeServices(params))
+    );
+    AWS.mock("ECS", "describeClusters", (params, callback) =>
+      callback(null, data.describeClusters(params))
+    );
+    AWS.mock("ECS", "listClusters", (params, callback) =>
+      callback(null, data.listClusters(params))
+    );
+    AWS.mock("ECS", "listServices", (params, callback) =>
+      callback(null, data.listServices(params))
+    );
+  });
+
+  it("returns list of services spun up by hammertime", () => {
+    return listServicesToStart(defaultOperatingTimezone).then(
+      hammertimedServices => {
+        assert.equal(hammertimedServices.length, 1);
+        assert.equal(
+          hammertimedServices[0].serviceArn,
+          "arn:aws:ecs:service:3-R-hammertimed"
+        );
+      }
+    );
+  });
+
+  afterEach(() => {
+    AWS.restore("ECS", "describeServices");
+    AWS.restore("ECS", "describeClusters");
+    AWS.restore("ECS", "listClusters");
+    AWS.restore("ECS", "listServices");
+  });
+});

--- a/test/ecs/listServicesToStop.test.js
+++ b/test/ecs/listServicesToStop.test.js
@@ -1,0 +1,47 @@
+const assert = require("assert");
+const AWS = require("aws-sdk-mock");
+const listServicesToStop = require("../../src/ecs/listServicesToStop.js");
+const defaultOperatingTimezone = require("../../src/config.js").defaultOperatingTimezone;
+const data = require("./mockData.js");
+
+describe("listServicesToStop()", () => {
+  beforeEach(() => {
+    AWS.mock("ECS", "describeServices", (params, callback) =>
+      callback(null, data.describeServices(params))
+    );
+    AWS.mock("ECS", "describeClusters", (params, callback) =>
+      callback(null, data.describeClusters(params))
+    );
+    AWS.mock("ECS", "listClusters", (params, callback) =>
+      callback(null, data.listClusters(params))
+    );
+    AWS.mock("ECS", "listServices", (params, callback) =>
+      callback(null, data.listServices(params))
+    );
+  });
+
+  it("returns list of services spun down by hammertime", () => {
+    return listServicesToStop(defaultOperatingTimezone).then(
+      hammertimeableServices => {
+        const valid = [
+          "arn:aws:ecs:service:1-R-unhammertimed",
+          "arn:aws:ecs:service:2-R-unhammertimed"
+        ];
+        assert.equal(hammertimeableServices.length, 2);
+        assert.equal(
+          hammertimeableServices.filter(service =>
+            valid.some(validService => validService === service.serviceArn)
+          ).length,
+          2
+        );
+      }
+    );
+  });
+
+  afterEach(() => {
+    AWS.restore("ECS", "describeServices");
+    AWS.restore("ECS", "describeClusters");
+    AWS.restore("ECS", "listClusters");
+    AWS.restore("ECS", "listServices");
+  });
+});

--- a/test/ecs/mockData.js
+++ b/test/ecs/mockData.js
@@ -1,0 +1,87 @@
+module.exports = {
+  listClusters: params => {
+    return {
+      clusterArns: [
+        "arn:aws:ecs:cluster/1",
+        "arn:aws:ecs:cluster/2",
+        "arn:aws:ecs:cluster/3"
+      ]
+    }
+  },
+  listServices: params => {
+    switch (params.cluster) {
+      case "arn:aws:ecs:cluster/1":
+        return {
+          serviceArns: ["arn:aws:ecs:service:1-R", "arn:aws:ecs:service:2-R"]
+        };
+      case "arn:aws:ecs:cluster/2":
+        return {
+          serviceArns: ["arn:aws:ecs:service:3-R"]
+        };
+      default:
+        return {
+          serviceArns: []
+        };
+    }
+  },
+  describeClusters: params => {
+    return {
+      clusters: [
+        { clusterArn: "arn:aws:ecs:cluster/1" },
+        { clusterArn: "arn:aws:ecs:cluster/2" },
+        { clusterArn: "arn:aws:ecs:cluster/3" }
+      ]
+    };
+  },
+  describeServices: params => {
+    switch (params.cluster) {
+      case "arn:aws:ecs:cluster/1":
+        return {
+          services: [
+            {
+              serviceArn: "arn:aws:ecs:service:1-R-unhammertimed",
+              clusterArn: "arn:aws:ecs:cluster/1",
+              desiredCount: 2,
+              runningCount: 2,
+              launchType: "FARGATE",
+              tags: [{ key: "key!", value: "value!" }]
+            },
+            {
+              serviceArn: "arn:aws:ecs:service:2-R-unhammertimed",
+              clusterArn: "arn:aws:ecs:cluster/1",
+              desiredCount: 2,
+              runningCount: 2,
+              launchType: "FARGATE",
+              tags: [{ key: "key!", value: "value!" }]
+            }
+          ]
+        };
+      case "arn:aws:ecs:cluster/2":
+        return {
+          services: [
+            {
+              serviceArn: "arn:aws:ecs:service:3-R-hammertimed",
+              clusterArn: "arn:aws:ecs:cluster/1",
+              desiredCount: 0,
+              runningCount: 0,
+              launchType: "FARGATE",
+              tags: [
+                {
+                  key: "stop:hammertime",
+                  value: "date"
+                },
+                {
+                  key: "hammertime:originalServiceSize",
+                  value: "2"
+                }
+              ]
+            }
+          ]
+        };
+      default:
+        return {
+          services: []
+        };
+    }
+  }
+};


### PR DESCRIPTION
ECS Services running on Fargate are currently not able to be Hammertimed as there is no underlying EC2 instance that can be stopped. This PR adds support for stopping Fargate services by reducing the number of desired tasks down to zero during the hammertime window.
